### PR TITLE
Docker OverlayFS compatibility: implements subset POSIX standards

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,6 +17,14 @@ if [ -z $KEYSTONE_DB_HOST ]; then
     KEYSTONE_DB_HOST=localhost
     # start mysql locally
     service mysql restart
+
+    #Docker OverlayFS compatibility: implements subset POSIX standards
+    #https://docs.docker.com/storage/storagedriver/overlayfs-driver/
+    #ALT: attach /var/lib/mysql as a volume to avoid timeout
+    if [ $? ] ; then
+        find /var/lib/mysql -type f -exec touch {} \;
+        service mysql restart
+    fi
 else
     if [ -z $KEYSTONE_DB_ROOT_PASSWD_IF_REMOTED ]; then
         echo "Your'are using Remote MySQL Database; "


### PR DESCRIPTION
Issue 1 - MySQL does not start with overlay2 on docker for OSX
Changes: if DB does not start forces copy-up operation on /var/lib/mysql and retries
Refs #1 Closes #1